### PR TITLE
Repro shepherd

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -36,7 +36,7 @@ module.exports = {
         // auto open browser or not
         openBrowser: true,
         publicPath: '/',
-        port: 8081,
+        port: 9000,
 
         // If for example you are using Quasar Play
         // to generate a QR code then on each dev (re)compilation

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "qs": "^6.5.1",
     "quasar-extras": "0.x",
     "quasar-framework": "^0.14.6",
+    "tether-shepherd": "^1.8.1",
     "vue": "^2.5.2",
     "vue-router": "^2.7.0",
     "vue-router-multiguard": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "vue": "^2.5.2",
     "vue-router": "^2.7.0",
     "vue-router-multiguard": "^1.0.3",
+    "vue-tour": "^1.0.1",
     "vuelidate": "^0.6.1",
     "vuex": "^3.0.1"
   },

--- a/src/components/Home.vue
+++ b/src/components/Home.vue
@@ -15,17 +15,65 @@
             <q-list no-border link inset-separator>
                 <q-list-header>Essential Links</q-list-header>
 
-                <div
-                    v-for="link in links"
-                    :data-v-step="link.label"
-                >
+                <div v-for="link in links" :id="`tour-step-${link.label}`">
                     <q-side-link item :to="link.to">
                         <q-item-side :icon="link.icon"/>
                         <q-item-main :label="link.label" :sublabel="link.sublabel"/>
+                        <v-tour name="sampleTour" :steps="steps">
+                            <template slot-scope="tour">
+                                <q-popover
+                                    v-for="(step, index) in tour.steps"
+                                    :value="tour.currentStep === index"
+                                    :key="index"
+                                >
+                                    <q-card flat>
+                                        <q-card-title>
+                                            {{ step.header.title }}
+                                        </q-card-title>
+                                        <q-card-main>
+                                            {{ step.content }}
+                                        </q-card-main>
+                                        <q-card-actions>
+                                            <q-btn
+                                                flat
+                                                color="primary"
+                                                @click="tour.stop"
+                                                v-if="!tour.isLast"
+                                            >
+                                                Skip tour
+                                            </q-btn>
+                                            <q-btn
+                                                flat
+                                                color="primary"
+                                                @click="tour.previousStep"
+                                                v-if="!tour.isFirst"
+                                            >
+                                                Previous
+                                            </q-btn>
+                                            <q-btn
+                                                flat
+                                                color="primary"
+                                                @click="tour.nextStep"
+                                                v-if="!tour.isLast"
+                                            >
+                                                Next
+                                            </q-btn>
+                                            <q-btn
+                                                flat
+                                                color="primary"
+                                                @click="tour.stop"
+                                                v-if="tour.isLast"
+                                            >
+                                                Finish
+                                            </q-btn>
+                                        </q-card-actions>
+                                    </q-card>
+                                </q-popover>
+                            </template>
+                        </v-tour>
                     </q-side-link>
                 </div>
             </q-list>
-            <v-tour name="sampleTour" :steps="steps"/>
         </div>
 
         <router-view/>
@@ -45,7 +93,13 @@
         QListHeader,
         QBtn,
         QIcon,
+        QCard,
+        QCardTitle,
+        QCardMain,
+        QCardActions,
+        QPopover,
     } from 'quasar';
+    import Shepherd from 'tether-shepherd';
 
     export default {
         name: 'Home',
@@ -62,6 +116,11 @@
             QListHeader,
             QBtn,
             QIcon,
+            QCard,
+            QCardTitle,
+            QCardMain,
+            QCardActions,
+            QPopover,
         },
 
         data() {
@@ -79,9 +138,6 @@
                             title: 'Docs'
                         },
                         content: 'This is the Docs page',
-                        params: {
-                            placement: 'left',
-                        }
                     },
                     {
                         target: '[data-v-step="Forums"]',
@@ -89,13 +145,6 @@
                             title: 'Forums',
                         },
                         content: 'This is the Forums page',
-                        params: {
-                            placement: 'left',
-                            preventOverflow: {
-                                enabled: true,
-                                boundariesElement: 'viewport',
-                            }
-                        }
                     },
                     {
                         target: '[data-v-step="Chat"]',
@@ -116,7 +165,18 @@
         },
 
         mounted() {
-            this.$tours.sampleTour.start();
+            const tour = new Shepherd.Tour();
+            tour.addStep('Docs', {
+                text: 'This is the Docs page',
+                attachTo: '#tour-step-Docs',
+                buttons: [
+                    {
+                        text: 'Next',
+                        action: tour.next
+                    }
+                ]
+            });
+            tour.start();
         }
     };
 </script>

--- a/src/components/Home.vue
+++ b/src/components/Home.vue
@@ -1,0 +1,125 @@
+<template>
+    <q-layout ref="layout" view="hHr LpR lFf" :right-breakpoint="1100">
+        <q-toolbar slot="header">
+            <q-btn flat @click="$refs.layout.toggleLeft()">
+                <q-icon name="menu"/>
+            </q-btn>
+
+            <q-toolbar-title>
+                Layout Header
+                <span slot="subtitle">Optional subtitle</span>
+            </q-toolbar-title>
+        </q-toolbar>
+
+        <div slot="left">
+            <q-list no-border link inset-separator>
+                <q-list-header>Essential Links</q-list-header>
+
+                <div
+                    v-for="link in links"
+                    :data-v-step="link.label"
+                >
+                    <q-side-link item :to="link.to">
+                        <q-item-side :icon="link.icon"/>
+                        <q-item-main :label="link.label" :sublabel="link.sublabel"/>
+                    </q-side-link>
+                </div>
+            </q-list>
+            <v-tour name="sampleTour" :steps="steps"/>
+        </div>
+
+        <router-view/>
+    </q-layout>
+</template>
+
+<script>
+    import {
+        QLayout,
+        QToolbar,
+        QToolbarTitle,
+        QList,
+        QItem,
+        QSideLink,
+        QItemMain,
+        QItemSide,
+        QListHeader,
+        QBtn,
+        QIcon,
+    } from 'quasar';
+
+    export default {
+        name: 'Home',
+
+        components: {
+            QLayout,
+            QToolbar,
+            QToolbarTitle,
+            QList,
+            QItem,
+            QSideLink,
+            QItemMain,
+            QItemSide,
+            QListHeader,
+            QBtn,
+            QIcon,
+        },
+
+        data() {
+            return {
+                links: [
+                    {to: '/docs', icon: 'school', label: 'Docs', sublabel: 'quasar-framework.org'},
+                    {to: '/forum', icon: 'record_voice_over', label: 'Forums', sublabel: 'forum.quasar-framework.org'},
+                    {to: '/chat', icon: 'chat', label: 'Chat', sublabel: 'Quasar Lobby'},
+                    {to: '/twitter', icon: 'rss feed', label: 'Twitter', sublabel: '@quasar-framework'},
+                ],
+                steps: [
+                    {
+                        target: '[data-v-step="Docs"]',
+                        header: {
+                            title: 'Docs'
+                        },
+                        content: 'This is the Docs page',
+                        params: {
+                            placement: 'left',
+                        }
+                    },
+                    {
+                        target: '[data-v-step="Forums"]',
+                        header: {
+                            title: 'Forums',
+                        },
+                        content: 'This is the Forums page',
+                        params: {
+                            placement: 'left',
+                            preventOverflow: {
+                                enabled: true,
+                                boundariesElement: 'viewport',
+                            }
+                        }
+                    },
+                    {
+                        target: '[data-v-step="Chat"]',
+                        header: {
+                            title: 'Chat',
+                        },
+                        content: 'This is the Chat page',
+                    },
+                    {
+                        target: '[data-v-step="Twitter"]',
+                        header: {
+                            title: 'Twitter',
+                        },
+                        content: 'This is the Twitter page',
+                    },
+                ]
+            };
+        },
+
+        mounted() {
+            this.$tours.sampleTour.start();
+        }
+    };
+</script>
+
+<style>
+</style>

--- a/src/plugins/index.js
+++ b/src/plugins/index.js
@@ -5,6 +5,9 @@ import ToastPlugin from './toast';
 import i18nPlugin from './i18n';
 import GoogleAPIPlugin from './google-api';
 import JWTPlugin from './jwt';
+import VueTour from 'vue-tour';
+
+require('vue-tour/dist/vue-tour.css');
 
 export default [
     Quasar,
@@ -14,4 +17,5 @@ export default [
     i18nPlugin,
     GoogleAPIPlugin,
     JWTPlugin,
+    VueTour,
 ];

--- a/src/router.js
+++ b/src/router.js
@@ -7,10 +7,10 @@ Vue.use(VueRouter);
  * Uncomment this section and use "load()" if you want
  * to lazy load routes.
  */
-/* function load (component) {
+function load (component) {
   // '@' is aliased to src/components
   return () => import(`@/${component}.vue`)
-} */
+}
 
 export default new VueRouter({
     /*
@@ -26,5 +26,6 @@ export default new VueRouter({
      */
 
     routes: [
+        { path: '/', component: load('Home') }
     ]
 });


### PR DESCRIPTION
Just run `npm run dev`

- shepherd puts the component in the center of the screen instead of attaching it. Might be an issue of component being mounted first before the slots get mounted thus `document.querySelector` will return null.
